### PR TITLE
create forks under target for easy inspection

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,7 +1,7 @@
 
 templatecontrol {
   #baseDirectory = ${user.home}"/work/templates"
-  baseDirectory = ${java.io.tmpdir}
+  baseDirectory = "target/forks"
 
   github {
     upstream = "playframework"

--- a/src/main/scala/templatecontrol/TemplateControl.scala
+++ b/src/main/scala/templatecontrol/TemplateControl.scala
@@ -77,8 +77,10 @@ class TemplateControl(config: TemplateControlConfig, githubClient: GithubClient)
 
   private def projectControl(templateDir: File, templateName: String)
                              (branchFunction: GitProject => Seq[BranchResult]): ProjectResult = {
+
+    logger.info(s"template dir: $templateDir")
     if (templateDir.exists) {
-      throw new IllegalStateException(s"$templateDir already exists!")
+      templateDir.delete()
     }
 
     // Clone a git repo for this template.
@@ -238,7 +240,10 @@ object TemplateControl {
     val perms = PosixFilePermissions.fromString("rwx------")
     val attrs = PosixFilePermissions.asFileAttribute(perms)
 
-    val tempFile: File = Files.createTempDirectory(baseDirectory.toJava.toPath, "", attrs)
+    logger.info(s"base dir: $baseDirectory")
+    val tempFile: File =
+      if (!baseDirectory.isDirectory) Files.createDirectory(baseDirectory.toJava.toPath, attrs)
+      else baseDirectory
 
     // Note this only happens if you don't interrupt or crash the JVM in some way.
     tempFile.toJava.deleteOnExit()


### PR DESCRIPTION
Instead of creating forks on random tmp folders, this PR changes TemplateControl to create the forks under `target/forks`. 

This is very convenient in combination with `run --no-push`. We can run it and jump to `target/forks/{project}` to inspect the changes.