### PR TITLE
Fix relative path issue in scripts/create-forks-play.sh

### DIFF
--- a/scripts/create-forks-play.sh
+++ b/scripts/create-forks-play.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-. templates-play.sh
-. lib-fork.sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. "$DIR/templates-play.sh"
+. "$DIR/lib-fork.sh"
 
 create-forks $play_github "${play_templates[@]}"


### PR DESCRIPTION
Allows it to be run from any directory (like the root of the repo.)