### PR TITLE
Dedup mergify rules

### DIFF
--- a/templates/.mergify.yml
+++ b/templates/.mergify.yml
@@ -22,16 +22,13 @@ pull_request_rules:
         method: squash
         strict: smart
 
-  # delete any branch when already merged
-  # doesn't matter if marked with labels or not
   - name: delete branch after merge
     conditions:
       - merged
     actions:
       delete_head_branch: {}
 
-  # delete 'merge-when-green' label if present and merged
-  - name: remove label after merge
+  - name: remove merge-when-green label after merge
     conditions:
       - merged
       - label=merge-when-green
@@ -39,8 +36,7 @@ pull_request_rules:
       label:
         remove: [merge-when-green]
 
-  # delete 'template-control' label if present and merged
-  - name: remove label after merge
+  - name: remove template-control label after merge
     conditions:
       - merged
       - label=template-control


### PR DESCRIPTION
I think
https://github.com/playframework/play-scala-isolated-slick-example/pull/74/checks?check_run_id=47906653
failed because there are two rules with the same name.