### PR TITLE
disable travis updates

### DIFF
--- a/src/main/resources/2.6.x.conf
+++ b/src/main/resources/2.6.x.conf
@@ -8,7 +8,7 @@ templatecontrol {
       { path = "/LICENSE", template = "LICENSE" },
       { path = "/NOTICE", template = "NOTICE" },
       { path = "/.mergify.yml", template = ".mergify.yml" },
-      { path = "/.travis.yml", template = ".travis.yml" }
+      # { path = "/.travis.yml", template = ".travis.yml" }
     ]
 
     # finders look for files and substitute text without replacing the entire file.

--- a/src/main/resources/2.7.x.conf
+++ b/src/main/resources/2.7.x.conf
@@ -7,7 +7,7 @@ templatecontrol {
     copy = [
       { path = "/LICENSE", template = "LICENSE" },
       { path = "/NOTICE", template = "NOTICE" },
-      { path = "/.travis.yml", template = ".travis.yml" }
+      # { path = "/.travis.yml", template = ".travis.yml" }
     ]
 
     # finders look for files and substitute text without replacing the entire file.


### PR DESCRIPTION
This PR disable the travis update. 

We have already propagated the change we want to all templates (both 2.6.x and 2.7.x). 

Some templates still have a special travis build and enabling it forces a manual intervention. 

