### PR TITLE
Simplified mergify rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,19 +3,10 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
-      - label=merge-when-green
     actions:
       merge:
         method: merge
         strict: smart
-
-  - name: Delete the merge-when-green label after merge
-    conditions:
-      - merged
-      - label=merge-when-green
-    actions:
-      label:
-        remove: [merge-when-green]
 
   - name: Delete the PR branch after merge
     conditions:

--- a/src/main/scala/templatecontrol/live/LiveGitProject.scala
+++ b/src/main/scala/templatecontrol/live/LiveGitProject.scala
@@ -86,7 +86,7 @@ class LiveGitProject(workingDir: File, upstream: GHRepository, remote: GHReposit
           """.stripMargin
     upstream
       .createPullRequest(title, head, base, body)
-      .setLabels("merge-when-green", "template-control")
+      .setLabels("merge-when-green")
   }
 
   override def fetch(): Unit = {

--- a/templates/.mergify.yml
+++ b/templates/.mergify.yml
@@ -4,7 +4,6 @@ pull_request_rules:
       - status-success=continuous-integration/travis-ci/pr
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
-      - label=merge-when-green
       - label!=block-merge
     actions:
       merge:
@@ -15,7 +14,6 @@ pull_request_rules:
     conditions:
       - status-success=continuous-integration/travis-ci/pr
       - label=merge-when-green
-      - label=template-control
       - label!=block-merge
     actions:
       merge:
@@ -35,11 +33,3 @@ pull_request_rules:
     actions:
       label:
         remove: [merge-when-green]
-
-  - name: remove template-control label after merge
-    conditions:
-      - merged
-      - label=template-control
-    actions:
-      label:
-        remove: [template-control]


### PR DESCRIPTION
This PR is removing the the `template-control` label as well as it doesn't require `merge-when-green` for human approved PRs.