### PR TITLE
Delete the label removal Mergify rule

### DIFF
--- a/templates/.mergify.yml
+++ b/templates/.mergify.yml
@@ -25,11 +25,3 @@ pull_request_rules:
       - merged
     actions:
       delete_head_branch: {}
-
-  - name: remove merge-when-green label after merge
-    conditions:
-      - merged
-      - label=merge-when-green
-    actions:
-      label:
-        remove: [merge-when-green]


### PR DESCRIPTION
It causes the previous rule (merge PRs that are ready) to re-check or
re-run and then fail/cancel because it doesn't match, because the label
isn't present.  So let's avoid having it look like our merged PRs are
red.