### PR TITLE
Update template mergify rules

### DIFF
--- a/templates/.mergify.yml
+++ b/templates/.mergify.yml
@@ -1,8 +1,10 @@
 pull_request_rules:
-  - name: automatic merge on CI success require review
+  - name: Merge PRs that are ready
     conditions:
       - status-success=Travis CI - Pull Request
+      - status-success=typesafe-cla-validator
       - "#approved-reviews-by>=1"
+      - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
       - label!=status:block-merge
     actions:
@@ -10,9 +12,12 @@ pull_request_rules:
         method: squash
         strict: smart
 
-  - name: automatic merge on CI success for TemplateControl
+  - name: Merge TemplateControl's PRs that are ready
     conditions:
       - status-success=Travis CI - Pull Request
+      - "#review-requested=0"
+      - "#changes-requested-reviews-by=0"
+      - label!=status:block-merge
       - label=status:merge-when-green
       - label!=status:block-merge
     actions:
@@ -20,7 +25,7 @@ pull_request_rules:
         method: squash
         strict: smart
 
-  - name: delete branch after merge
+  - name: Delete the PR branch after merge
     conditions:
       - merged
     actions:


### PR DESCRIPTION
**NOTE** Merge with caution: once this is merged, the next propagation
of changes to the template repos won't auto-merge because Mergify
doesn't auto-merge when its rules are being changed. (tracked as #113)

For regular PRs:
* include CLA validation success
* block if more reviews are requested

For TemplateControl's PRs:
* block if more reviews are requested
* block if changes requested
* block on block-merged